### PR TITLE
correct branch of CI workflow

### DIFF
--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -3,9 +3,9 @@ name: ros CI
 on:
   push:
     # you may want to configure the branches that this should be run on here.
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   test_docker: # On Linux, iterates on all ROS 1 and ROS 2 distributions.


### PR DESCRIPTION
the branch was incorrect, as the main branch is `main`.