### PR TITLE
several improvements of workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
 
 # get the source tree and analyse it for its package.xml only
 FROM base as sourcefilter
-COPY . /tmp/src
+COPY ./src /tmp/src
 # remove everything that isn't package.xml
 RUN find /tmp/src -type f \! -name "package.xml" -print | xargs rm -rf
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-	"name": "L-CAS Humble",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "lcas.lincoln.ac.uk/lcas/devcontainer/hunter_ros2",
+	"name": "L-CAS Humble Devcontainer",
 	"dockerFile": "./Dockerfile",
 	"context": "..",
 
@@ -22,19 +20,22 @@
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
+	// Here we run `colcon build` to build the workspace initially, (to speed up later builds), and we keep going if it fails for some packages to get as much compiled as possible
+	"postCreateCommand": ".devcontainer/post-create.sh",
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	"remoteUser": "ros",
+	"updateRemoteUserUID": true, // ensure internal user has the same UID as the host user and update file permissions
 	"customizations": {
 		"vscode": {
 			"extensions": [
 				"ms-python.python",
 				"GitHub.vscode-pull-request-github",
-				"ms-vscode.cpptools"
+				"ms-vscode.cpptools",
+				"JaehyunShim.vscode-ros2",
+				"nonanonno.vscode-ros2",
+				"deitry.colcon-helper",
+				"github.vscode-github-actions"
 			]
 		}
 	}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+function add_config_if_not_exist {
+    if ! grep -F -q "$1" $HOME/.bashrc; then
+        echo "$1" >> $HOME/.bashrc
+    fi
+}
+
+add_config_if_not_exist "source /opt/ros/humble/setup.bash"
+LOCAL_SETUP_FILE=`pwd`/install/setup.bash
+add_config_if_not_exist "if [ -r $LOCAL_SETUP_FILE ]; then source $LOCAL_SETUP_FILE; fi"
+
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install --continue-on-error

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+./LICENSE
+./README.md
+devel/
+log/
+build/
+bin/
+lib/
+install/
+*~

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -1,0 +1,25 @@
+name: 'devcontainer CI' 
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout from github
+        uses: actions/checkout@v3
+      - name: extract the github reference
+        run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Build and run dev container task
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: lcas.lincoln.ac.uk/devcontainer/${{ github.repository}}
+          push: never
+          imageTag: ${{ env.BRANCH }}
+          #runCmd: "bash .devcontainer/run-ci.sh"

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -16,10 +16,13 @@ jobs:
         uses: actions/checkout@v3
       - name: extract the github reference
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: "image name from repo name"
+        id: docker_image_name
+        run: echo "docker_image=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' |sed 's/[^0-9,a-z,A-Z,=,_,\/]/-/g' >>${GITHUB_OUTPUT}
       - name: Build and run dev container task
         uses: devcontainers/ci@v0.3
         with:
-          imageName: lcas.lincoln.ac.uk/devcontainer/${{ github.repository}}
+          imageName: lcas.lincoln.ac.uk/devcontainer/${{ steps.docker_image_name.outputs.docker_image }}
           push: never
           imageTag: ${{ env.BRANCH }}
           #runCmd: "bash .devcontainer/run-ci.sh"

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  build:
+  build_devcontainer:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout from github

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 devel/
-logs/
+log/
 build/
 bin/
 lib/
+install/
 msg_gen/
 srv_gen/
 msg/*Action.msg

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The devcontainer includes a light desktop interface. To utilize this feature:
 ### Enjoy Development!
 
 By leveraging this setup, you can develop on a remote machine with a lightweight desktop interface. Magic! 
+All ROS2 packages should go into the `src/` folder. Create them with `ros2 pkg create...`. 
+
+The devcontainer tries to install all dependencies of the workspace automatically as much as possible, and also tries to build the workspace when it is created, to speed up later colcon builds.
 
 ### References
 


### PR DESCRIPTION
* add devcontainer CI build workflow
* contain an `src/` directory, which is where all packages should go, as then the root of the repository can itself serve as a colcon workspace (works best for dev containers)
* configures `.dockerignore` and `.gitignore` to ensure that any colcon-generated files (as repository root is also workspace) don't end up in code base etc.
* create a `post-create` command that is executed on container creation and auto-configures the `~/.bashrc` with the local workspace and attempts to build the whole colcon workspace. This is to speed up later builds as all packages that can be build already automatically are.
* updated documentation to match this
