### PR TITLE
2 dev containers to chose from

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,8 @@
-FROM lcas.lincoln.ac.uk/lcas/ros:humble as base
+ARG BASE_IMAGE=ros:humble
+
+FROM ${BASE_IMAGE} as base
+
+USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -22,12 +26,15 @@ RUN rosdep update && apt-get update
 RUN cd /tmp/src && rosdep install --from-paths . --ignore-src -r -y && cd && rm -rf /tmp/src
 
 FROM depbuilder as final
-# add user ros with sudo rights
-RUN useradd -ms /bin/bash ros && echo "ros:ros" | chpasswd && adduser ros sudo
+# add user ros with sudo rights if it doesn't exist
+RUN if ! id ros; then \
+        useradd -ms /bin/bash ros && echo "ros:ros" | chpasswd && adduser ros sudo; \
+        echo "ALL ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
+        echo "source /opt/ros/humble/setup.bash" >> /etc/bash.bashrc; \
+    else echo "user ros already exists"; \
+    fi
 
 # add sudo without password
-RUN echo "ALL ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-
-RUN echo "source /opt/ros/humble/setup.bash" >> /etc/bash.bashrc
+ENV DEBIAN_FRONTEND=noninteractive
 
 USER ros

--- a/.devcontainer/cuda-opengl/devcontainer.json
+++ b/.devcontainer/cuda-opengl/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "L-CAS Humble CUDA-OpenGL Devcontainer",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"args": {
+			"BASE_IMAGE": "lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda-opengl"
+		},
+		"context": "../.."
+	},
+
+	"forwardPorts": [5801],
+	"portsAttributes": {
+		"5801": {
+			"label": "desktop",
+			"onAutoForward": "openBrowser"
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// Here we run `colcon build` to build the workspace initially, (to speed up later builds), and we keep going if it fails for some packages to get as much compiled as possible
+	"postCreateCommand": "/opt/entrypoint.sh /bin/true; .devcontainer/post-create.sh",
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "ros",
+	"updateRemoteUserUID": true, // ensure internal user has the same UID as the host user and update file permissions
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"GitHub.vscode-pull-request-github",
+				"ms-vscode.cpptools",
+				"JaehyunShim.vscode-ros2",
+				"nonanonno.vscode-ros2",
+				"deitry.colcon-helper",
+				"github.vscode-github-actions"
+			]
+		}
+	},
+	"hostRequirements": {
+		"gpu": "optional",
+		"cpus": 2,
+		"memory": "8gb"
+	}
+}

--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -1,9 +1,14 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-	"name": "L-CAS Humble Devcontainer",
-	"dockerFile": "./Dockerfile",
-	"context": "..",
+	"name": "L-CAS Humble Default Devcontainer",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"args": {
+			"BASE_IMAGE": "lcas.lincoln.ac.uk/lcas/ros:humble"
+		},
+		"context": "../.."
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
@@ -14,9 +19,9 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [6080],
 	"portsAttributes": {
-	  "6080": {
+	  	"6080": {
 			"label": "desktop"
-	  }
+	  	}
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
@@ -38,5 +43,10 @@
 				"github.vscode-github-actions"
 			]
 		}
+	},
+	"hostRequirements": {
+		"gpu": "optional",
+		"cpus": 2,
+		"memory": "8gb"
 	}
 }

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -11,6 +11,11 @@ on:
 jobs:
   build_devcontainer:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: 
+          - default
+          - cuda-opengl
     steps:
       - name: Checkout from github
         uses: actions/checkout@v3
@@ -23,6 +28,7 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           imageName: lcas.lincoln.ac.uk/devcontainer/${{ steps.docker_image_name.outputs.docker_image }}
+          configFile: ./.devcontainer/${{ matrix.config }}/devcontainer.json
           push: never
-          imageTag: ${{ env.BRANCH }}
+          imageTag: ${{ matrix.config }}-${{ env.BRANCH }}
           #runCmd: "bash .devcontainer/run-ci.sh"


### PR DESCRIPTION
There are no 2 dev containers to chose from:
1. `default`: As before
2. `cuda-opengl: This is the new one that provides CUDA and OpenGL acceleration based on the new L-CAS NVIDIA ROS2 image (`lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda-opengl`)