### PR TITLE
Add disk space cleanup step in dev-container.yml

### DIFF
--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB


### PR DESCRIPTION
This pull request adds a step to the `build_devcontainer` workflow to free up disk space on the runner before building the dev container. This helps prevent disk space issues during CI runs.

Improvements to CI reliability:

* [`.github/workflows/dev-container.yml`](diffhunk://#diff-14a7446724467800063b1cea57ac0c5989993efb0595bc6f026e043c8c86493cR15-R29): Added the `jlumbroso/free-disk-space@v1` action to remove unnecessary files and packages, freeing up about 6 GB of disk space before starting the build process.